### PR TITLE
Fixing "findComponentArgs" to work with single or multiple mixins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = function (src) {
+  if (this.cacheable) {
+    this.cacheable();
+  }
 
   var omniscientReloadablePath = require.resolve('./omniscient-reloadable').replace('.js', '');
 


### PR DESCRIPTION
When you try to use this loader with components that use mixins, and you want to use just a single mixin, this code is needed so that it doesn't assume that the mixin argument is always an array.
